### PR TITLE
Test: Save Reporting Date as UTC

### DIFF
--- a/Modules/Test/classes/ScoreReporting/class.ilObjTestScoreSettingsDatabaseRepository.php
+++ b/Modules/Test/classes/ScoreReporting/class.ilObjTestScoreSettingsDatabaseRepository.php
@@ -70,7 +70,8 @@ class ilObjTestScoreSettingsDatabaseRepository implements ScoreSettingsRepositor
         if ($reporting_date) {
             $reporting_date = \DateTimeImmutable::createFromFormat(
                 self::STORAGE_DATE_FORMAT,
-                $reporting_date
+                $reporting_date,
+                new DateTimeZone('UTC')
             );
         } else {
             $reporting_date = null;

--- a/Modules/Test/classes/ScoreReporting/ilObjTestSettingsResultSummary.php
+++ b/Modules/Test/classes/ScoreReporting/ilObjTestSettingsResultSummary.php
@@ -161,7 +161,7 @@ class ilObjTestSettingsResultSummary extends TestSettings
 
     public function toStorage(): array
     {
-        $dat = $this->getReportingDate();
+        $dat = $this->getReportingDate()->setTimezone(new DateTimeZone('UTC'));
         if ($dat) {
             $dat = $dat->format(ilObjTestScoreSettingsDatabaseRepository::STORAGE_DATE_FORMAT);
         }


### PR DESCRIPTION
Ok, I played around with this a little bit.
I think we need to make sure that we generate a UTC-Date for saving in the Database. This would do that. This will lead to some trouble with already saved Entries, ...but as people saving them in 8 always saw a Date without Time, I don't think this is an issue. Older Entries made with ILIAS 7 will stay true to themselves ;-).